### PR TITLE
Fix whitelist variable name

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -65,12 +65,12 @@ self.addEventListener('fetch', event => {
 
 // Remove old caches
 self.addEventListener('activate', event => {
-  const cacheWhiteList = [CACHE_NAME];
+  const cacheWhitelist = [CACHE_NAME];
   event.waitUntil(
     caches.keys().then(cacheNames => {
       return Promise.all(
         cacheNames.map(cacheName => {
-          if (!cacheWhiteList.includes(cacheName)) {
+          if (!cacheWhitelist.includes(cacheName)) {
             console.log('Deleting old cache:', cacheName);
             return caches.delete(cacheName);
           }


### PR DESCRIPTION
## Summary
- rename `cacheWhiteList` to `cacheWhitelist` in service worker

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684084404a50832ebe534d3b5975adc3